### PR TITLE
Refactor

### DIFF
--- a/src/main/kotlin/app/civa/vaccination/domain/Name.kt
+++ b/src/main/kotlin/app/civa/vaccination/domain/Name.kt
@@ -5,6 +5,7 @@ private constructor(
     private val classification: String,
     private val commercial: String
 ) {
+    val key = this.classification
 
     constructor(builder: NameBuilder) : this(
         builder.classification.trim(),

--- a/src/main/kotlin/app/civa/vaccination/domain/Stash.kt
+++ b/src/main/kotlin/app/civa/vaccination/domain/Stash.kt
@@ -5,9 +5,9 @@ import java.util.*
 class Stash : HashMap<String, Collection<VaccineControl>>() {
 
     fun add(vaccine: Vaccine, quantity: Int = 1): VaccineControl {
-        val (vaccineName, control) = VaccineControl.from(quantity, vaccine).toPair()
+        val control = VaccineControl.from(quantity, vaccine)
 
-        this.merge(vaccineName, setOf(control)) { A, B -> A union B }
+        this.merge(vaccine.makeKey(), setOf(control)) { A, B -> A union B }
 
         return control
     }
@@ -22,24 +22,22 @@ class Stash : HashMap<String, Collection<VaccineControl>>() {
             ?: throw VaccineControlNotFoundException from id
 
     fun increaseStock(id: UUID, quantity: Int = 1): VaccineControl {
-        val (vaccineName, control) = this.findVaccineControlById(id).toPair()
-
+        val control = this.findVaccineControlById(id)
         val updatedControl = control.increaseBy(quantity)
-        this.updateInventory(vaccineName, updatedControl)
-
+        this updateInventoryWith updatedControl
         return updatedControl
     }
 
     fun retrieve(id: UUID, quantity: Int = 1): Vaccine {
-        val (vaccineName, control) = this.findVaccineControlById(id).toPair()
+        val control = this.findVaccineControlById(id)
         val (updatedControl, vaccine) = control.retrieve(quantity)
-
-        this.updateInventory(vaccineName, updatedControl)
-
+        this updateInventoryWith updatedControl
         return vaccine
     }
 
-    private fun updateInventory(vaccineName: String, updatedControl: VaccineControl) {
+    private infix fun updateInventoryWith(updatedControl: VaccineControl) {
+        val vaccineName = updatedControl.getVaccineKey()
+
         this[vaccineName] = this[vaccineName]!!
             .map { if (it.id == updatedControl.id) updatedControl else it }
     }

--- a/src/main/kotlin/app/civa/vaccination/domain/Vaccine.kt
+++ b/src/main/kotlin/app/civa/vaccination/domain/Vaccine.kt
@@ -6,7 +6,6 @@ private constructor(
     private val efficacy: Efficacy,
     private val fabrication: Fabrication
 ) {
-
     constructor(builder: VaccineBuilder) : this(
         builder.name,
         builder.efficacy,
@@ -18,6 +17,8 @@ private constructor(
         visitor.seeEfficacy(efficacy)
         visitor.seeFabrication(fabrication)
     }
+
+    fun makeKey() = this.name.key
 
     infix fun apply(petWeight: PetWeight) =
         VaccineApplication.from(vaccine = this, petWeight)

--- a/src/main/kotlin/app/civa/vaccination/domain/Vaccine.kt
+++ b/src/main/kotlin/app/civa/vaccination/domain/Vaccine.kt
@@ -23,12 +23,6 @@ private constructor(
     infix fun apply(petWeight: PetWeight) =
         VaccineApplication.from(vaccine = this, petWeight)
 
-    infix fun pairNameWith(application: VaccineApplication) =
-        name pairWith application
-
-    infix fun pairNameWith(control: VaccineControl) =
-        name pairWith control
-
     infix fun mustMatch(species: Species) = apply {
         efficacy mustMatch species
     }

--- a/src/main/kotlin/app/civa/vaccination/domain/VaccineApplication.kt
+++ b/src/main/kotlin/app/civa/vaccination/domain/VaccineApplication.kt
@@ -34,7 +34,7 @@ private constructor(
         visitor.seeCreatedOn(createdOn)
     }
 
-    fun toPair() = vaccine pairNameWith this
+    fun getKey() = vaccine.makeKey()
 
     infix fun mustMatch(species: Species) = apply {
         vaccine mustMatch species

--- a/src/main/kotlin/app/civa/vaccination/domain/VaccineControl.kt
+++ b/src/main/kotlin/app/civa/vaccination/domain/VaccineControl.kt
@@ -19,6 +19,20 @@ private constructor(
     private val quantity: Int,
     private val vaccine: Vaccine
 ) {
+    companion object {
+        /**
+         * Factory method that instantiates a new [VaccineControl] if the provided quantity
+         * is positive
+         * @return a new instance of VaccineControl
+         * @throws IllegalQuantityException when the quantity provided is not positive.
+         */
+        fun from(quantity: Int, vaccine: Vaccine) = VaccineControl(
+            id = UUID.randomUUID(),
+            quantity = quantity.mustBePositive(),
+            vaccine = vaccine.mustBeValid()
+        )
+    }
+
     /**
      * Increases [quantity] if the value provided is positive.
      * @return a new instance of [VaccineControl] with updated [quantity]
@@ -49,27 +63,18 @@ private constructor(
         return this.quantity - quantityWanted
     }
 
+    fun getVaccineKey() = this.vaccine.makeKey()
+
     fun toPair() = vaccine pairNameWith this
 
-    companion object {
-        /**
-         * Factory method that instantiates a new [VaccineControl] if the provided quantity
-         * is positive
-         * @return a new instance of VaccineControl
-         * @throws IllegalQuantityException when the quantity provided is not positive.
-         */
-        fun from(quantity: Int, vaccine: Vaccine) = VaccineControl(
-            id = UUID.randomUUID(),
-            quantity = quantity.mustBePositive(),
-            vaccine = vaccine.mustBeValid()
-        )
-    }
 }
 
-private fun Int.mustBePositive(): Int {
-    if (this <= 0) throw IllegalQuantityException from this
-    else return this
-}
+private fun Int.mustBePositive() =
+    when (this <= 0){
+        true -> throw IllegalQuantityException from this
+        else -> this
+    }
+
 
 private infix fun Int.mustHaveEnough(quantityWanted: Int) {
     if (this < quantityWanted) throw

--- a/src/main/kotlin/app/civa/vaccination/domain/VaccineControl.kt
+++ b/src/main/kotlin/app/civa/vaccination/domain/VaccineControl.kt
@@ -65,18 +65,16 @@ private constructor(
 
     fun getVaccineKey() = this.vaccine.makeKey()
 
-    fun toPair() = vaccine pairNameWith this
-
 }
 
 private fun Int.mustBePositive() =
-    when (this <= 0){
+    when (this <= 0) {
         true -> throw IllegalQuantityException from this
         else -> this
     }
 
-
 private infix fun Int.mustHaveEnough(quantityWanted: Int) {
-    if (this < quantityWanted) throw
-    IllegalQuantityException.of(this, quantityWanted)
+    when (this < quantityWanted) {
+        true -> throw IllegalQuantityException.of(this, quantityWanted)
+    }
 }

--- a/src/test/kotlin/app/civa/vaccination/domain/ApplicationsTest.kt
+++ b/src/test/kotlin/app/civa/vaccination/domain/ApplicationsTest.kt
@@ -14,7 +14,6 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.assertDoesNotThrow
 import java.util.*
@@ -23,69 +22,63 @@ class ApplicationsTest : BehaviorSpec({
     given("a vaccine application to be added") {
         `when`("it is the first application of that name") {
             then("it should be added successfully") {
-                val slot = slot<VaccineApplication>()
                 val vaccineMock = mockk<Vaccine>()
-                every {
-                    vaccineMock pairNameWith capture(slot)
-                } answers { "Name Test" to slot.captured }
+                every { vaccineMock.makeKey() } returns "Name Test"
 
                 val applications = Applications()
 
                 shouldNotThrowAny {
-                    applications add application {
+                    val application = application {
                         id = mockk()
                         vaccine = vaccineMock
                         createdOn = mockk()
                         petWeight = mockk()
                     }
+                    applications add application
+
+                    applications.shouldNotBeNull().shouldNotBeEmpty()
+                    applications shouldContain ("Name Test" to listOf(application))
+                    applications.size shouldBe 1
                 }
 
-                applications.shouldNotBeNull().shouldNotBeEmpty()
-                applications.size shouldBe 1
-                applications shouldContain ("Name Test" to listOf(slot.captured))
-
-                verify(exactly = 1) { vaccineMock pairNameWith capture(slot) }
+                verify { vaccineMock.makeKey() }
             }
         }
         `when`("it is not the first application of that name") {
             and("it has happened after interval") {
                 then("it should be added to applications successfully") {
-                    val slot = slot<VaccineApplication>()
                     val vaccineMock = mockk<Vaccine>()
-                    every {
-                        vaccineMock pairNameWith capture(slot)
-                    } answers { "Name Test" to slot.captured }
+                    every { vaccineMock.makeKey() } returns "Name Test"
 
                     val vaccineApplicationMock = mockk<VaccineApplication>()
                     every {
                         vaccineApplicationMock mapStatusFrom any()
                     } returns DateTimeStatus.VALID
-                    every {
-                        vaccineApplicationMock.toPair()
-                    } answers { "Name Test" to vaccineApplicationMock }
+                    every { vaccineApplicationMock.getKey() } returns "Name Test"
 
                     val applications = Applications()
                     applications add vaccineApplicationMock
 
                     shouldNotThrowAny {
-                        applications add application {
+                        val application = application {
                             id = mockk()
                             vaccine = vaccineMock
                             createdOn = mockk()
                             petWeight = mockk()
                         }
+                        applications add application
+
+                        applications.shouldNotBeNull().shouldNotBeEmpty()
+                        applications.size shouldBe 1
+                        applications shouldContain ("Name Test" to listOf(
+                            vaccineApplicationMock,
+                            application
+                        ))
                     }
 
-                    applications.shouldNotBeNull().shouldNotBeEmpty()
-                    applications.size shouldBe 1
-                    applications shouldContain ("Name Test" to listOf(
-                        vaccineApplicationMock,
-                        slot.captured
-                    ))
-
                     verify {
-                        vaccineApplicationMock.toPair()
-                        vaccineMock pairNameWith capture(slot)
+                        vaccineApplicationMock.getKey()
+                        vaccineMock.makeKey()
                         vaccineApplicationMock mapStatusFrom any()
                     }
                 }
@@ -97,39 +90,36 @@ class ApplicationsTest : BehaviorSpec({
                         row(DateTimeStatus.SAME),
                         row(DateTimeStatus.INTERVAL)
                     ) {
-                        val slot = slot<VaccineApplication>()
                         val vaccineMock = mockk<Vaccine>()
-                        every {
-                            vaccineMock pairNameWith capture(slot)
-                        } answers { "Name Test" to slot.captured }
+                        every { vaccineMock.makeKey() } returns "Name Test"
 
                         val vaccineApplicationMock = mockk<VaccineApplication>()
                         every { vaccineApplicationMock mapStatusFrom any() } returns it
-                        every {
-                            vaccineApplicationMock.toPair()
-                        } answers { "Name Test" to vaccineApplicationMock }
+                        every { vaccineApplicationMock.getKey() } returns "Name Test"
 
                         val applications = Applications()
                         applications add vaccineApplicationMock
 
                         shouldThrowExactly<InvalidApplicationException> {
-                            applications add application {
+                            val application = application {
                                 id = mockk()
                                 vaccine = vaccineMock
                                 createdOn = mockk()
                                 petWeight = mockk()
                             }
+                            applications add application
+
+                            applications.shouldNotBeNull().shouldNotBeEmpty()
+                            applications.size shouldBe 1
+                            applications shouldNotContain ("Name Test" to listOf(
+                                vaccineApplicationMock,
+                                application
+                            ))
                         }
-                        applications.shouldNotBeNull().shouldNotBeEmpty()
-                        applications.size shouldBe 1
-                        applications shouldNotContain ("Name Test" to listOf(
-                            vaccineApplicationMock,
-                            slot.captured
-                        ))
 
                         verify {
-                            vaccineApplicationMock.toPair()
-                            vaccineMock pairNameWith capture(slot)
+                            vaccineApplicationMock.getKey()
+                            vaccineMock.makeKey()
                             vaccineApplicationMock mapStatusFrom any()
                         }
                     }
@@ -141,11 +131,8 @@ class ApplicationsTest : BehaviorSpec({
         `when`("the application is found") {
             and("there's only one application with certain name") {
                 then("it should be removed successfully") {
-                    val slots = mutableListOf<VaccineApplication>()
                     val vaccineMock = mockk<Vaccine>()
-                    every {
-                        vaccineMock pairNameWith capture(slots)
-                    } answers { "Name Test" to slots.last() }
+                    every { vaccineMock.makeKey() } returns "Name Test"
 
                     val uuid = UUID.randomUUID()
                     val vaccineApplication = application {
@@ -163,16 +150,13 @@ class ApplicationsTest : BehaviorSpec({
                     applications.shouldNotBeNull().shouldBeEmpty()
                     applications shouldNotContain ("Name Test" to listOf(vaccineApplication))
 
-                    verify { vaccineMock pairNameWith ofType<VaccineApplication>() }
+                    verify { vaccineMock.makeKey() }
                 }
             }
             and("there's more than one application with the same name") {
                 then("it should be removed successfully") {
-                    val slots = mutableListOf<VaccineApplication>()
                     val vaccineMock = mockk<Vaccine>()
-                    every {
-                        vaccineMock pairNameWith capture(slots)
-                    } answers { "Name Test" to slots.last() }
+                    every { vaccineMock.makeKey() } returns "Name Test"
 
                     val createdOnMock = mockk<ApplicationDateTime>()
                     every { createdOnMock mapStatus any() } returns DateTimeStatus.VALID
@@ -199,7 +183,7 @@ class ApplicationsTest : BehaviorSpec({
                     applications.shouldNotBeNull().shouldNotBeEmpty()
                     applications shouldNotContain ("Name Test" to listOf(vaccineApplication))
 
-                    verify { vaccineMock pairNameWith ofType<VaccineApplication>() }
+                    verify { vaccineMock.makeKey() }
                 }
             }
         }
@@ -217,11 +201,8 @@ class ApplicationsTest : BehaviorSpec({
     given("an application id to be found") {
         `when`("the application is present") {
             then("it must be retrieved") {
-                val slots = mutableListOf<VaccineApplication>()
                 val vaccineMock = mockk<Vaccine>()
-                every {
-                    vaccineMock pairNameWith capture(slots)
-                } answers { "Name Test" to slots.last() }
+                every { vaccineMock.makeKey() } returns "Vaccine Key"
 
                 val uuid = UUID.randomUUID()
                 val vaccineApplication = application {

--- a/src/test/kotlin/app/civa/vaccination/domain/StashTest.kt
+++ b/src/test/kotlin/app/civa/vaccination/domain/StashTest.kt
@@ -24,13 +24,10 @@ class StashTest : BehaviorSpec({
     given("an empty stash") {
         `when`("a valid vaccine and a positive quantity is provided") {
             then("vaccine control should be added to the stash") {
-                val slot = slot<VaccineControl>()
                 val vaccineMock = mockk<Vaccine>()
 
                 every { vaccineMock.mustBeValid() } returns vaccineMock
-                every { vaccineMock pairNameWith capture(slot) } answers {
-                    Pair("Vaccine Test", slot.captured)
-                }
+                every { vaccineMock.makeKey() } returns "Vaccine Key"
 
                 val stash = Stash()
 
@@ -40,22 +37,20 @@ class StashTest : BehaviorSpec({
 
                 stash.shouldNotBeNull().shouldNotBeEmpty()
                 stash.size shouldBeExactly 1
-                stash.contains("Vaccine Test").shouldBeTrue()
+                stash.contains("Vaccine Key").shouldBeTrue()
 
                 verify {
                     vaccineMock.mustBeValid()
-                    vaccineMock pairNameWith ofType<VaccineControl>()
+                    vaccineMock.makeKey()
                 }
             }
         }
         `when`("a valid vaccine is provided") {
             then("one vaccine control should be added to the stash") {
-                val slot = slot<VaccineControl>()
                 val vaccineMock = mockk<Vaccine>()
+
                 every { vaccineMock.mustBeValid() } returns vaccineMock
-                every { vaccineMock pairNameWith capture(slot) } answers {
-                    Pair("Vaccine Test", slot.captured)
-                }
+                every { vaccineMock.makeKey() } returns "Vaccine Key"
 
                 val stash = Stash()
 
@@ -65,11 +60,11 @@ class StashTest : BehaviorSpec({
 
                 stash.shouldNotBeNull().shouldNotBeEmpty()
                 stash.size shouldBeExactly 1
-                stash.contains("Vaccine Test").shouldBeTrue()
+                stash.contains("Vaccine Key").shouldBeTrue()
 
                 verify {
                     vaccineMock.mustBeValid()
-                    vaccineMock pairNameWith ofType<VaccineControl>()
+                    vaccineMock.makeKey()
                 }
             }
         }
@@ -125,19 +120,16 @@ class StashTest : BehaviorSpec({
     given("an stash with a collection of vaccine control") {
         `when`("an existing vaccine name is provided") {
             then("a collection of control should be returned") {
-                val slot = slot<VaccineControl>()
                 val vaccineMock = mockk<Vaccine>()
 
                 every { vaccineMock.mustBeValid() } returns vaccineMock
-                every {
-                    vaccineMock pairNameWith capture(slot)
-                } answers { Pair("Vaccine Test", slot.captured) }
+                every { vaccineMock.makeKey() } returns "Vaccine Key"
 
                 val stash = Stash()
                 val control = stash.add(vaccineMock)
 
                 shouldNotThrowAny {
-                    val controlList = stash findVaccineByName "Vaccine Test"
+                    val controlList = stash findVaccineByName "Vaccine Key"
 
                     controlList.shouldNotBeNull().shouldNotBeEmpty()
                     controlList.contains(control)
@@ -146,13 +138,10 @@ class StashTest : BehaviorSpec({
         }
         `when`("a valid control id and a quantity is provided") {
             then("control should be increased") {
-                val slot = slot<VaccineControl>()
                 val vaccineMock = mockk<Vaccine>()
 
                 every { vaccineMock.mustBeValid() } returns vaccineMock
-                every {
-                    vaccineMock pairNameWith capture(slot)
-                } answers { Pair("Vaccine Test", slot.captured) }
+                every { vaccineMock.makeKey() } returns "Vaccine Key"
 
                 val stash = Stash()
                 val control = stash.add(vaccineMock)
@@ -162,13 +151,13 @@ class StashTest : BehaviorSpec({
 
                     updatedControl shouldNotBeSameInstanceAs control
 
-                    stash.contains("Vaccine Test").shouldBeTrue()
+                    stash.contains("Vaccine Key").shouldBeTrue()
 
-                    stash["Vaccine Test"]!!
+                    stash["Vaccine Key"]!!
                         .contains(updatedControl)
                         .shouldBeTrue()
 
-                    stash["Vaccine Test"]!!
+                    stash["Vaccine Key"]!!
                         .contains(control)
                         .shouldBeFalse()
                 }
@@ -176,13 +165,10 @@ class StashTest : BehaviorSpec({
         }
         `when`("a valid control id is provided") {
             then("a pair of control and vaccine should be retrieved") {
-                val slot = slot<VaccineControl>()
                 val vaccineMock = mockk<Vaccine>()
 
                 every { vaccineMock.mustBeValid() } returns vaccineMock
-                every {
-                    vaccineMock pairNameWith capture(slot)
-                } answers { Pair("Vaccine Test", slot.captured) }
+                every { vaccineMock.makeKey() } returns "Vaccine Key"
 
                 val stash = Stash()
                 val control = stash.add(vaccineMock)
@@ -196,13 +182,10 @@ class StashTest : BehaviorSpec({
                 }
             }
             then("it should find a single control") {
-                val slot = slot<VaccineControl>()
                 val vaccineMock = mockk<Vaccine>()
 
                 every { vaccineMock.mustBeValid() } returns vaccineMock
-                every {
-                    vaccineMock pairNameWith capture(slot)
-                } answers { Pair("Vaccine Test", slot.captured) }
+                every { vaccineMock.makeKey() } returns "Vaccine Key"
 
                 val stash = Stash()
                 val control = stash.add(vaccineMock)

--- a/src/test/kotlin/app/civa/vaccination/domain/VaccineApplicationTest.kt
+++ b/src/test/kotlin/app/civa/vaccination/domain/VaccineApplicationTest.kt
@@ -40,30 +40,6 @@ class VaccineApplicationTest : BehaviorSpec({
         }
     }
     given("a vaccine application") {
-        `when`("toPair method is called") {
-            then("it should return a pair of vaccine name and application") {
-                val slot = slot<VaccineApplication>()
-                val vaccineMock = mockk<Vaccine>()
-
-                every {
-                    vaccineMock pairNameWith capture(slot)
-                } answers { "Name test" to slot.captured }
-
-                val application = application {
-                    id = mockk()
-                    vaccine = vaccineMock
-                    petWeight = mockk()
-                    createdOn = mockk()
-                }
-
-                val (name, applicationFromPair) = application.toPair()
-
-                name shouldBe "Name test"
-                applicationFromPair shouldBeSameInstanceAs application
-
-                verify(exactly = 1) { vaccineMock pairNameWith application }
-            }
-        }
         `when`("a matching species is provided") {
             then("it must match") {
                 val vaccineMock = mockk<Vaccine>()

--- a/src/test/kotlin/app/civa/vaccination/domain/VaccineTest.kt
+++ b/src/test/kotlin/app/civa/vaccination/domain/VaccineTest.kt
@@ -143,28 +143,6 @@ class VaccineTest : BehaviorSpec({
             }
         }
     }
-    given("a vaccine application") {
-        `when`("it pairs with a Vaccine name") {
-            then("it should return the pair") {
-                val applicationMock = mockk<VaccineApplication>()
-
-                val nameMock = mockk<Name>()
-                every { nameMock pairWith ofType<VaccineApplication>() } returns
-                        ("Antirrábica" to applicationMock)
-
-                val pair = vaccine {
-                    name = nameMock
-                    efficacy = mockk()
-                    fabrication = mockk()
-                } pairNameWith applicationMock
-
-                pair.first shouldBe "Antirrábica"
-                pair.second shouldBeSameInstanceAs applicationMock
-
-                verify(exactly = 1) { nameMock pairWith ofType<VaccineApplication>() }
-            }
-        }
-    }
     given("a valid instance of Vaccine") {
         `when`("it accepts a VaccineVisitor") {
             then("visitor methods should be called in sequence") {


### PR DESCRIPTION
# Refactor
This refactor goal was to improve code readability by changing `toPair()` calls to better methods